### PR TITLE
test(ci): canary — validate vendor-based matrix + aggregation on trunk

### DIFF
--- a/.ci-trigger.md
+++ b/.ci-trigger.md
@@ -2,10 +2,13 @@
 
 Trivial test file to open a PR against `open-vela/packages_fe_examples:trunk`
 and exercise the post-merge CI pipeline introduced in
-[open-vela/public-actions#58](https://github.com/open-vela/public-actions/pull/58):
+[open-vela/public-actions#58](https://github.com/open-vela/public-actions/pull/58)
+and stabilized by [open-vela/public-actions#60](https://github.com/open-vela/public-actions/pull/60):
 
 - `ci-tasks` matrix grouped by vendor (`goldfish`, `sil`, `aurix`, `flagchip`, `qemu`)
 - new `qemu` and `flagchip/kcore0` build tasks
 - `post-processing` aggregating via `needs.ci-tasks.result`
+- `vela_*.bin` copy made optional so qemu configs don't fail in artifact backup
+- `post-processing` itself exits non-zero when any matrix group failed
 
 No source code change intended; delete this file after validation.

--- a/.ci-trigger.md
+++ b/.ci-trigger.md
@@ -1,0 +1,11 @@
+# CI canary trigger
+
+Trivial test file to open a PR against `open-vela/packages_fe_examples:trunk`
+and exercise the post-merge CI pipeline introduced in
+[open-vela/public-actions#58](https://github.com/open-vela/public-actions/pull/58):
+
+- `ci-tasks` matrix grouped by vendor (`goldfish`, `sil`, `aurix`, `flagchip`, `qemu`)
+- new `qemu` and `flagchip/kcore0` build tasks
+- `post-processing` aggregating via `needs.ci-tasks.result`
+
+No source code change intended; delete this file after validation.


### PR DESCRIPTION
## Purpose

Canary PR to exercise the `trunk` CI pipeline updated by [open-vela/public-actions#58](https://github.com/open-vela/public-actions/pull/58) (merged):

- `ci-tasks` matrix reorganized into vendor-based groups: `goldfish`, `sil`, `aurix`, `flagchip`, `qemu`.
- New `qemu` group (7 `@cmake` builds) and re-enabled `flagchip/kcore0@cmake`.
- `post-processing` aggregates via `needs.ci-tasks.result` — correctly reports `success` only when every matrix instance succeeds.

## Expected behavior

The CI workflow dispatched by `.github/workflows/ci.yml` (`uses: open-vela/public-actions/.github/workflows/ci.yml@trunk`) should:

- Spin up 5 parallel `ci-tasks` runners, one per vendor group (`fail-fast: false`).
- Produce build artifacts named `Build_Package_goldfish`, `Build_Package_qemu`, etc.
- Run `post-processing` after all groups complete, reporting overall status based on `needs.ci-tasks.result`.

## Notes

- No source change intended; the only file added (`.ci-trigger.md`) can be dropped after validation.
- This PR will be closed once the pipeline results are captured.
- End-to-end equivalence was already validated in a self-test run inside the public-actions fork:
  https://github.com/liujinye-sys/public-actions/actions/runs/25424153926