### PR TITLE
test(ci): canary — validate dev pipeline after public-actions#62

### DIFF
--- a/.ci-trigger.md
+++ b/.ci-trigger.md
@@ -1,0 +1,7 @@
+# Canary PR trigger
+
+This file exists only to trigger the CI workflow for validating the
+consolidated changes landed in open-vela/public-actions#62 (matrix by
+vendor + qemu builds + accurate status reporting + manifest PR apply).
+
+It will be removed once the pipeline is validated.


### PR DESCRIPTION
## Purpose

Canary PR to exercise the `dev` CI pipeline updated by [open-vela/public-actions#62](https://github.com/open-vela/public-actions/pull/62) (merged), which consolidated #55, #59, and #61.

## What changed in ci-real.yml on dev

- `ci-tasks` matrix reorganized into vendor-based groups: `goldfish`, `sil`, `aurix`, `flagchip`, `qemu` (5 parallel runners instead of 2).
- New `qemu` group (7 `@cmake` builds).
- `flagchip/kcore0@cmake` is included (vendor fix already landed).
- `post-processing` aggregates via `needs.ci-tasks.result` — `success` only when every matrix instance succeeds.
- `vela_*.bin` copy is now best-effort (won't fail on qemu-* configs that don't produce it).
- `post-processing` exits `1` when `needs.ci-tasks.result != success`, so a single required check (`ci / ci_dev / post-processing`) correctly gates merges.
- `setup` now applies manifest PR changes before `repo sync` (only when PR is from `open-vela/manifests`).

## Expected behavior

The dev `.github/workflows/ci.yml` dispatcher routes to `ci-real.yml@dev`, which should:

- Spin up 5 parallel `ci-tasks` runners, one per vendor group (`fail-fast: false`).
- Produce build artifacts named `Build_Package_goldfish`, `Build_Package_sil`, `Build_Package_aurix`, `Build_Package_flagchip`, `Build_Package_qemu`.
- Run `post-processing` after all groups, reporting overall status via `needs.ci-tasks.result`.

## Notes

- No source change intended; only adds `.ci-trigger.md` which is removed after validation.
- This PR will be closed once the pipeline results are captured.
- Self-test fork run (same matrix + aggregation): [liujinye-sys/public-actions/actions/runs/25424153926](https://github.com/liujinye-sys/public-actions/actions/runs/25424153926)

Related-to: open-vela/public-actions#62